### PR TITLE
Advice by id#6

### DIFF
--- a/app/services/advice_service.rb
+++ b/app/services/advice_service.rb
@@ -1,12 +1,21 @@
 class AdviceService
   def slip_query(query)
-    response = conn.get("/advice/search/#{query}")
-    JSON.parse(response.body, symbolize_names: true)
+    Rails.cache.fetch("advice_query_#{query}", expires_in: 1.day) do
+      response = conn.get("/advice/search/#{query}")
+      JSON.parse(response.body, symbolize_names: true)
+    end
   end
 
   def random_advice
     response = conn.get("/advice")
     JSON.parse(response.body, symbolize_names: true)
+  end
+
+  def slip_id(id)
+    Rails.cache.fetch("advice_slip_id_#{id}", expires_in: 1.day) do
+      response = conn.get("/advice/#{id}")
+      JSON.parse(response.body, symbolize_names: true)
+    end
   end
 
   private

--- a/spec/services/advice_service_spec.rb
+++ b/spec/services/advice_service_spec.rb
@@ -19,6 +19,18 @@ describe AdviceService do
     expect(result[:message][:type]).to eq("notice")
     expect(result[:message][:text]).to eq("No advice slips found matching that search term.")
   end
+  it "can return multiple advice slips matching one query" do
+    service = AdviceService.new
+    query = "run"
+
+    result = service.slip_query(query)
+
+    expect(result[:total_results]).to eq("2")
+    expect(result[:slips][0]).to have_key(:advice)
+    expect(result[:slips][0]).to have_key(:slip_id)
+    expect(result[:slips][1]).to have_key(:advice)
+    expect(result[:slips][1]).to have_key(:slip_id)
+  end
   it "can return random advice" do
     service = AdviceService.new
 
@@ -27,5 +39,14 @@ describe AdviceService do
     expect(result.count).to eq(1)
     expect(result[:slip]).to have_key(:advice)
     expect(result[:slip]).to have_key(:slip_id)
+  end
+  it "can return advice by id" do
+    service = AdviceService.new
+    id = 3
+
+    result = service.slip_id(id)
+
+    expect(result[:slip]).to have_key(:advice)
+    expect(result[:slip][:advice]).to eq("Don't eat non-snow-coloured snow.")
   end
 end

--- a/spec/services/advice_service_spec.rb
+++ b/spec/services/advice_service_spec.rb
@@ -49,4 +49,13 @@ describe AdviceService do
     expect(result[:slip]).to have_key(:advice)
     expect(result[:slip][:advice]).to eq("Don't eat non-snow-coloured snow.")
   end
+  it "returns a notice if no id matches" do
+    service = AdviceService.new
+    id = 219
+
+    result = service.slip_query(id)
+
+    expect(result[:message][:type]).to eq("notice")
+    expect(result[:message][:text]).to eq("No advice slips found matching that search term.")
+  end
 end


### PR DESCRIPTION
## Waffle Card number(s):
Closes #6 
## What does this PR do?
Adds method for finding advice by id.  Includes happy & sad path testing.  Also add low-level caching for finding advice by id & query string.
## Any additional context you want to provide?
Coverage will be at 100% for the first time the tests are run in a 24-hour period due to caching.  Coverage will drop to 75% after this during that same 24-hour period.